### PR TITLE
Remove outline when search bar focused & Change + size

### DIFF
--- a/style.css
+++ b/style.css
@@ -100,7 +100,7 @@ input {
 }
 
 p {
-    font-size: 32px;
+    font-size: 30px;
     position: relative;
     top: 2px;
     margin: 0;
@@ -110,3 +110,6 @@ footer {
     position: absolute;
     bottom: 5px; right: 5px;
 }
+ input:focus {
+    outline: none;
+ }


### PR DESCRIPTION
Unfocus the search bar when clicked.
Change the + sign in the "Add shortcut" button from 32px to 30px.